### PR TITLE
Fix garbled diff

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -75,6 +75,15 @@ function! agit#launch(args)
         endif
       endfor
     endif
+    let g:agit_diff_cp932 = 0
+    if exists('g:agit_diff_stat_cp932_pattern')
+      for pattern in g:agit_diff_stat_cp932_pattern
+        if match(git_root, pattern) != -1
+          let g:agit_diff_cp932 = 1
+          break
+        endif
+      endfor
+    endif
     call agit#bufwin#agit_tabnew(git)
     let t:git = git
     if s:fugitive_enabled

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -145,6 +145,15 @@ function! s:git.diff(hash) dict
     let ignoresp = g:agit_ignore_spaces ? '-w' : ''
     let diff = agit#git#exec('show -p '. ignoresp .' ' . a:hash, self.git_root)
   endif
+
+  if g:agit_diff_cp932
+    let stat_len = match(diff, 'diff --git')
+    if stat_len != -1
+      let diff = ( (stat_len == 0) ? '' : diff[0:stat_len - 1] ) .
+        \ iconv(diff[stat_len:-1], 'cp932', &enc)
+    endif
+  endif
+
   return diff
 endfunction
 


### PR DESCRIPTION
コミットメッセージがUTF-8で、ソースコードが、
SJISの場合に、SJISが文字化けしてしまうのを修正